### PR TITLE
new release

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+autopep8
 mock
 pylint
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,13 @@ commands =
         --cov-report term-missing \
         --pep8 \
         {posargs}
+    autopep8 \
+        --in-place \
+        --aggressive \
+        --recursive \
+        --max-line-length 119 \
+        --ignore=W503 \
+        steenzout
 
 
 [testenv:docs]
@@ -46,6 +53,7 @@ whitelist_externals =
 
 
 [testenv:venv]
+envdir = py27
 commands =
     {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6},2{7}
+envlist = py3{6},py2{7}
 deps = -rrequirements.txt
 
 


### PR DESCRIPTION
- added [autopep8](https://pypi.python.org/pypi/autopep8)
- use [autopep8](https://pypi.python.org/pypi/autopep8) to make code comply with PEP8
- `venv` to use `py27` virtual environment Python interpreter
